### PR TITLE
lss_connector: more efficient serialization and deserialization of LssMsg and LssRes

### DIFF
--- a/glyph/Cargo.toml
+++ b/glyph/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 sphinx-auther = { path = "../auther", version = "0.1.12" }
 anyhow = "1"
 serde_json = "1.0"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.168", default-features = false, features = ["derive"] }
 rmp-serde = "1.1.0"
 # serde_bolt = { version = "0.2", default-features = false }
 hex = "0.4.3"

--- a/lss-connector/Cargo.toml
+++ b/lss-connector/Cargo.toml
@@ -16,7 +16,7 @@ sphinx-glyph = { path = '../glyph' }
 vls-protocol-signer = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "e199c70cbacd3404e7cecf95bb75ca02afd4cffd", default-features = false, features = ["std", "secp-lowmemory"] }
 # vls-protocol-signer = { path = "../../validating-lightning-signer/vls-protocol-signer", default-features = false, features = ["std", "secp-lowmemory"] }
 log = "0.4"
-serde = "1.0.1"
+serde = "1.0.168"
 anyhow = "1"
 secp256k1 = { version = "0.24.0", features = ["rand-std", "bitcoin_hashes"] }
 rmp-serde = "1.1.0"

--- a/lss-connector/Cargo.toml
+++ b/lss-connector/Cargo.toml
@@ -27,5 +27,3 @@ vls-frontend = { git = "https://gitlab.com/lightning-signer/validating-lightning
 # lightning-storage-server = { path = "../../validating-lightning-signer/lightning-storage-server", optional = true }
 # vls-frontend = { path = "../../validating-lightning-signer/vls-frontend", optional = true }
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread"], optional = true }
-
-

--- a/lss-connector/Cargo.toml
+++ b/lss-connector/Cargo.toml
@@ -27,3 +27,7 @@ vls-frontend = { git = "https://gitlab.com/lightning-signer/validating-lightning
 # lightning-storage-server = { path = "../../validating-lightning-signer/lightning-storage-server", optional = true }
 # vls-frontend = { path = "../../validating-lightning-signer/vls-frontend", optional = true }
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread"], optional = true }
+
+[[bin]]
+name = "playground"
+path = "src/playground.rs"

--- a/lss-connector/src/broker.rs
+++ b/lss-connector/src/broker.rs
@@ -119,7 +119,7 @@ impl LssBroker {
 
 pub async fn lss_handle(lss: &LssPersister, msg: &[u8]) -> Result<Vec<u8>> {
     log::info!("MSG {:?}", msg);
-    let res = Response::from_slice(msg)?.as_vls_muts()?;
+    let res = Response::from_slice(msg)?.into_vls_muts()?;
     log::info!("res::: {:?}", res);
     let client = lss.lock().await;
     let bm: BrokerMutations = if res.muts.is_empty() {

--- a/lss-connector/src/msgs.rs
+++ b/lss-connector/src/msgs.rs
@@ -69,21 +69,21 @@ impl Msg {
         let ret = rmp_serde::from_slice(s)?;
         Ok(ret)
     }
-    pub fn as_init(&self) -> Result<Init> {
+    pub fn into_init(self) -> Result<Init> {
         match self {
-            Msg::Init(i) => Ok(i.clone()),
+            Msg::Init(i) => Ok(i),
             _ => Err(anyhow!("not an init msg")),
         }
     }
-    pub fn as_created(&self) -> Result<BrokerMutations> {
+    pub fn into_created(self) -> Result<BrokerMutations> {
         match self {
-            Msg::Created(m) => Ok(m.clone()),
+            Msg::Created(m) => Ok(m),
             _ => Err(anyhow!("not a created msg")),
         }
     }
-    pub fn as_stored(&self) -> Result<BrokerMutations> {
+    pub fn into_stored(self) -> Result<BrokerMutations> {
         match self {
-            Msg::Stored(m) => Ok(m.clone()),
+            Msg::Stored(m) => Ok(m),
             _ => Err(anyhow!("not a stored msg")),
         }
     }
@@ -112,21 +112,21 @@ impl Response {
         let ret = rmp_serde::from_slice(s)?;
         Ok(ret)
     }
-    pub fn as_init(&self) -> Result<InitResponse> {
+    pub fn into_init(self) -> Result<InitResponse> {
         match self {
-            Response::Init(i) => Ok(i.clone()),
+            Response::Init(i) => Ok(i),
             _ => Err(anyhow!("not an init msg")),
         }
     }
-    pub fn as_created(&self) -> Result<SignerMutations> {
+    pub fn into_created(self) -> Result<SignerMutations> {
         match self {
-            Response::Created(m) => Ok(m.clone()),
+            Response::Created(m) => Ok(m),
             _ => Err(anyhow!("not a created msg")),
         }
     }
-    pub fn as_vls_muts(&self) -> Result<SignerMutations> {
+    pub fn into_vls_muts(self) -> Result<SignerMutations> {
         match self {
-            Response::VlsMuts(m) => Ok(m.clone()),
+            Response::VlsMuts(m) => Ok(m),
             _ => Err(anyhow!("not a VlsMuts msg")),
         }
     }

--- a/lss-connector/src/msgs.rs
+++ b/lss-connector/src/msgs.rs
@@ -46,10 +46,15 @@ pub struct InitResponse {
 
 impl Msg {
     pub fn to_vec(&self) -> Result<Vec<u8>> {
-        Ok(rmp_serde::to_vec_named(&self)?)
+        let arr: Box<[u8]> = Box::new([0u8; 9000]);
+        let mut buff = std::io::Cursor::new(arr);
+        rmp_serde::encode::write_named(&mut buff, &self)?;
+        let ret = buff.into_inner().into_vec();
+        Ok(ret)
     }
     pub fn from_slice(s: &[u8]) -> Result<Self> {
-        Ok(rmp_serde::from_slice(s)?)
+        let ret = rmp_serde::from_slice(s)?;
+        Ok(ret)
     }
     pub fn as_init(&self) -> Result<Init> {
         match self {
@@ -72,10 +77,15 @@ impl Msg {
 }
 impl Response {
     pub fn to_vec(&self) -> Result<Vec<u8>> {
-        Ok(rmp_serde::to_vec_named(&self)?)
+        let arr: Box<[u8]> = Box::new([0u8; 9000]);
+        let mut buff = std::io::Cursor::new(arr);
+        rmp_serde::encode::write_named(&mut buff, &self)?;
+        let ret = buff.into_inner().into_vec();
+        Ok(ret)
     }
     pub fn from_slice(s: &[u8]) -> Result<Self> {
-        Ok(rmp_serde::from_slice(s)?)
+        let ret = rmp_serde::from_slice(s)?;
+        Ok(ret)
     }
     pub fn as_init(&self) -> Result<InitResponse> {
         match self {

--- a/lss-connector/src/playground.rs
+++ b/lss-connector/src/playground.rs
@@ -1,0 +1,47 @@
+use lss_connector::msgs::*;
+//use rmp_serde::encode::Error;
+/*
+use rand::{
+    distributions::{Alphanumeric, DistString},
+    Rng,
+};
+use vls_protocol_signer::lightning_signer::persist::Mutations;
+*/
+
+fn main() {
+    //let mut std_rng = rand::thread_rng();
+
+    let init = Msg::Init(Init {
+        server_pubkey: [0u8; 33],
+    });
+
+    let _z = init.to_vec();
+
+    /*
+        let auth_token = vec![
+            3, 1, 5, 6, 7, 3, 3, 2, 1, 5, 1, 2, 3, 4, 6, 1, 2, 3, 4, 5, 1, 2, 4, 5, 6, 7, 3, 4, 2, 1,
+            3, 4,
+        ];
+        //println!("len: {}", auth_token.len());
+
+        let init_response = Response::Init(InitResponse {
+            client_id: [0u8; 33],
+            auth_token,
+            nonce: Some([0u8; 32]),
+        });
+        let _ = init_response.to_vec();
+
+        let _z: Mutations = Mutations::from_vec(
+            (0..std_rng.gen_range(100..200))
+                .map(|_| {
+                    (
+                        Alphanumeric.sample_string(&mut rand::thread_rng(), std_rng.gen_range(10..20)),
+                        (std_rng.gen(), vec![std_rng.gen(); std_rng.gen_range(0..10)]),
+                    )
+                })
+                .collect(),
+        );
+
+    */
+    //println!("{:?}", z);
+}

--- a/lss-connector/src/signer.rs
+++ b/lss-connector/src/signer.rs
@@ -144,7 +144,7 @@ pub fn handle_lss_msg(
             // get the previous lss msg (where i sent signer muts)
             let prev_lssmsg = Response::from_slice(&previous.1)?;
             // println!("previous lss res: {:?}", prev_lssmsg);
-            let sm = prev_lssmsg.as_vls_muts()?;
+            let sm = prev_lssmsg.into_vls_muts()?;
             if sm.muts.is_empty() {
                 // empty muts? dont need to check server hmac
                 Ok((topics::VLS_RES.to_string(), previous.0))

--- a/lss-connector/src/signer.rs
+++ b/lss-connector/src/signer.rs
@@ -95,11 +95,11 @@ impl LssSigner {
 
         Ok((handler, res_bytes))
     }
-    pub fn client_hmac(&self, muts: Muts) -> [u8; 32] {
-        self.helper.client_hmac(&Mutations::from_vec(muts))
+    pub fn client_hmac(&self, mutations: &Mutations) -> [u8; 32] {
+        self.helper.client_hmac(mutations)
     }
-    pub fn server_hmac(&self, muts: Muts) -> [u8; 32] {
-        self.helper.server_hmac(&Mutations::from_vec(muts))
+    pub fn server_hmac(&self, mutations: &Mutations) -> [u8; 32] {
+        self.helper.server_hmac(mutations)
     }
     pub fn check_hmac(&self, bm: BrokerMutations) -> bool {
         self.helper
@@ -154,7 +154,7 @@ pub fn handle_lss_msg(
                     .try_into()
                     .map_err(|_| anyhow!("Invalid server hmac (not 32 bytes)"))?;
                 // check the original muts
-                let server_hmac = lss_signer.server_hmac(sm.muts);
+                let server_hmac = lss_signer.server_hmac(&Mutations::from_vec(sm.muts));
                 // send back the original VLS response finally
                 if server_hmac == shmac {
                     Ok((topics::VLS_RES.to_string(), previous.0))

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -22,7 +22,7 @@ vls-persist = { git = "https://gitlab.com/lightning-signer/validating-lightning-
 # vls-persist = { path = "../../validating-lightning-signer/vls-persist", default-features = false, features = ["std", "memo"], optional = true }
 log = "0.4"
 rand = "0.8"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.168", default-features = false, features = ["derive"] }
 hex = "0.4.3"
 bip39 = "1.0.1"
 anyhow = "1"

--- a/signer/src/mobile.rs
+++ b/signer/src/mobile.rs
@@ -51,7 +51,7 @@ pub fn run_init_1(
     args: Args,
     lss_msg1: Vec<u8>,
 ) -> Result<(RunReturn, RootHandlerBuilder, LssSigner)> {
-    let init = Msg::from_slice(&lss_msg1)?.as_init()?;
+    let init = Msg::from_slice(&lss_msg1)?.into_init()?;
     let server_pubkey = PublicKey::from_slice(&init.server_pubkey)?;
 
     let rhb = root_handler_builder(args)?;
@@ -69,7 +69,7 @@ pub fn run_init_2(
     lss_msg2: Vec<u8>,
 ) -> Result<(RunReturn, RootHandler, LssSigner)> {
     let (_res1, rhb, lss_signer) = run_init_1(args, lss_msg1)?;
-    let created = Msg::from_slice(&lss_msg2)?.as_created()?;
+    let created = Msg::from_slice(&lss_msg2)?.into_created()?;
     let (root_handler, res2) = lss_signer.build_with_lss(created, rhb)?;
     Ok((
         RunReturn::new_lss(topics::INIT_2_RES, res2),

--- a/signer/src/root.rs
+++ b/signer/src/root.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use lightning_signer::bitcoin::blockdata::constants::ChainHash;
 use lightning_signer::bitcoin::Network;
 use lightning_signer::node::NodeServices;
-use lightning_signer::persist::Persist;
+use lightning_signer::persist::{Mutations, Persist};
 use lightning_signer::policy::simple_validator::SimpleValidatorFactory;
 use lightning_signer::signer::StartingTimeFactory;
 use lightning_signer::util::clock::{Clock, StandardClock};
@@ -81,7 +81,7 @@ fn handle_inner(
     root_handler: &RootHandler,
     mut bytes: Vec<u8>,
     do_log: bool,
-) -> anyhow::Result<(Vec<u8>, Vec<(String, (u64, Vec<u8>))>)> {
+) -> anyhow::Result<(Vec<u8>, Mutations)> {
     //println!("Signer is handling these bytes: {:?}", bytes);
     let msgs::SerialRequestHeader {
         sequence,
@@ -120,13 +120,13 @@ fn handle_inner(
             Err(e) => return Err(anyhow!("root handler error: {:?}", e)),
         }
     };
-    let (vls_msg, muts) = reply;
+    let (vls_msg, mutations) = reply;
     // make the VLS message bytes
     let mut buf = Vec::new();
     write_serial_response_header(&mut &mut buf, sequence)?;
     msgs::write_vec(&mut &mut buf, vls_msg.as_vec())?;
     //println!("handled message, replying with: {:?}", out_md);
-    Ok((buf, muts.into_inner()))
+    Ok((buf, mutations))
 }
 
 pub fn handle(root_handler: &RootHandler, bytes: Vec<u8>, do_log: bool) -> anyhow::Result<Vec<u8>> {
@@ -140,12 +140,12 @@ pub fn handle_with_lss(
     bytes: Vec<u8>,
     do_log: bool,
 ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
-    let (out_bytes, muts) = handle_inner(root_handler, bytes, do_log)?;
-    let lss_bytes = if muts.is_empty() {
+    let (out_bytes, mutations) = handle_inner(root_handler, bytes, do_log)?;
+    let lss_bytes = if mutations.is_empty() {
         Vec::new()
     } else {
-        let client_hmac = lss_signer.client_hmac(muts.clone());
-        let lss_msg = LssResponse::VlsMuts(SignerMutations { client_hmac, muts });
+        let client_hmac = lss_signer.client_hmac(&mutations);
+        let lss_msg = LssResponse::VlsMuts(SignerMutations { client_hmac, muts: mutations.into_inner() });
         lss_msg.to_vec()?
     };
     Ok((out_bytes, lss_bytes))

--- a/vls-mqtt/src/lss.rs
+++ b/vls-mqtt/src/lss.rs
@@ -13,7 +13,7 @@ pub async fn init_lss(
     println!("INIT LSS!");
 
     let first_lss_msg = lss_rx.recv().await.ok_or(anyhow!("couldnt receive"))?;
-    let init = Msg::from_slice(&first_lss_msg.message)?.as_init()?;
+    let init = Msg::from_slice(&first_lss_msg.message)?.into_init()?;
     let server_pubkey = PublicKey::from_slice(&init.server_pubkey)?;
 
     let (lss_signer, res1) = LssSigner::new(&handler_builder, &server_pubkey);
@@ -23,7 +23,7 @@ pub async fn init_lss(
     }
 
     let second_lss_msg = lss_rx.recv().await.ok_or(anyhow!("couldnt receive"))?;
-    let created = Msg::from_slice(&second_lss_msg.message)?.as_created()?;
+    let created = Msg::from_slice(&second_lss_msg.message)?.into_created()?;
     println!("GOT THE CREATED MSG! {:?}", created);
 
     // build the root handler


### PR DESCRIPTION
Highlights:

- 3706570deb89198f28be7898790978a1dd5bca6e replaces the exponential growth in memory allocs of `std::Vec` with a linear progression, optimized for our serialization use case.
- 1526a403d391264c492c3c873b030bb521818751 bumps the serde dependency to take advantage of a fix there that allows for bigger upfront single memory allocs (2MiB), as opposed to starting at 4096 bytes, and then using the exponential progression of `std::Vec` to allocate the correct size buffer. In practice, this resulted in a memory allocation of 16K for a object of size 8K. Now we allocate exactly the memory we need upon deserialization.