### PR TITLE
signer: create vvcursor to parse msg bytes in a vec<vec<u8>>

### DIFF
--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -4,6 +4,7 @@ pub mod mobile;
 pub mod parser;
 pub mod root;
 pub mod rst;
+mod vvcursor;
 
 #[cfg(feature = "std")]
 pub mod policy;

--- a/signer/src/mobile.rs
+++ b/signer/src/mobile.rs
@@ -115,9 +115,14 @@ pub fn run_vls(
 ) -> Result<RunReturn> {
     let (_res, rh, approver, lss_signer) = run_init_2(args, state, lss_msg1, lss_msg2, velocity)?;
     let s1 = approver.control().get_state();
-    let (vls_res, lss_res, sequence, cmd, server_hmac) =
-        handle_with_lss(&rh, &lss_signer, vls_msg.to_vec(), expected_sequence, true)
-            .map_err(Error::msg)?;
+    let (vls_res, lss_res, sequence, cmd, server_hmac) = handle_with_lss(
+        &rh,
+        &lss_signer,
+        vec![vls_msg.to_vec()],
+        expected_sequence,
+        true,
+    )
+    .map_err(Error::msg)?;
     let mut ret = if lss_res.is_empty() {
         RunReturn::new_vls(topics::VLS_RES, vls_res, sequence, cmd)
     } else {

--- a/signer/src/vvcursor.rs
+++ b/signer/src/vvcursor.rs
@@ -1,0 +1,46 @@
+use std::io::Read;
+use std::io::Result;
+
+pub(crate) struct VvCursor {
+    pos: usize,
+    index: usize,
+    bytes: Vec<Vec<u8>>,
+}
+
+impl VvCursor {
+    pub(crate) fn new(bytes: Vec<Vec<u8>>) -> Self {
+        VvCursor {
+            pos: 0usize,
+            index: 0usize,
+            bytes,
+        }
+    }
+    pub(crate) fn _get_caps(&self) -> Vec<usize> {
+        self.bytes.iter().map(|vector| vector.capacity()).collect()
+    }
+}
+
+impl Read for VvCursor {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        if self.bytes.is_empty() {
+            return Ok(0);
+        }
+        let mut total = 0usize;
+        loop {
+            let n = (&(self.bytes[self.index])[self.pos..]).read(&mut buf[total..])?;
+            total += n;
+            if self.pos + n == self.bytes[self.index].len() {
+                self.bytes[self.index].clear();
+                self.bytes[self.index].shrink_to(0usize);
+                self.pos = 0;
+                self.index += 1;
+            } else {
+                self.pos += n;
+                return Ok(total);
+            }
+            if self.index == self.bytes.len() {
+                return Ok(total);
+            }
+        }
+    }
+}

--- a/vls-mqtt/src/main.rs
+++ b/vls-mqtt/src/main.rs
@@ -186,7 +186,7 @@ async fn rocket() -> _ {
             let s1 = approver.control().get_state();
             println!("RUN NOW: {:?}", &msg.expected_sequence);
             let res_res =
-                root::handle_with_lss(&rh_, &lss_signer, msg.message, msg.expected_sequence, false)
+                root::handle_with_lss(&rh_, &lss_signer, vec![msg.message], msg.expected_sequence, false)
                     .map_err(Error::msg);
             let s2 = approver.control().get_state();
             if s1 != s2 {


### PR DESCRIPTION
See https://github.com/stakwork/sphinx-key/pull/139

I'd be happy to add a feature of some kind so that mobile for example can pass a normal `Vec<u8>`, and esp32 can pass a `Vec<Vec<u8>>`