### PR TITLE
signer: create low memory feature for incoming vls bytes

### DIFF
--- a/lss-connector/Cargo.toml
+++ b/lss-connector/Cargo.toml
@@ -25,9 +25,9 @@ anyhow = { version = "1", default-features = false }
 secp256k1 = { version = "0.24.0", default-features = false, features = ["bitcoin_hashes"] }
 # broker libs
 # vls
-lightning-storage-server = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "9708f5281afe27a2ac5460679ba62a28567b79dc", optional = true }
-vls-frontend = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "9708f5281afe27a2ac5460679ba62a28567b79dc", optional = true }
-vls-protocol-signer = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "9708f5281afe27a2ac5460679ba62a28567b79dc", default-features = false, features = ["secp-lowmemory", "tracker_size_workaround"] }
+lightning-storage-server = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "300495658a1903a45a081771fdf2fe6883b057a7", optional = true }
+vls-frontend = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "300495658a1903a45a081771fdf2fe6883b057a7", optional = true }
+vls-protocol-signer = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "300495658a1903a45a081771fdf2fe6883b057a7", default-features = false, features = ["secp-lowmemory", "tracker_size_workaround"] }
 # local
 # lightning-storage-server = { path = "../../vls/lightning-storage-server", optional = true }
 # vls-frontend = { path = "../../vls/vls-frontend", optional = true }

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -18,6 +18,7 @@ std = ["vls-persist/std", "vls-protocol-signer/std", "vls-protocol/std", "lss-co
 broker-test = ["lss-connector/broker"]
 no-std = ["vls-protocol-signer/no-std", "vls-persist/no-std", "lss-connector/no-std", "sphinx-glyph/no-std"]
 no-native = ["lss-connector/no-native"]
+lowmemory = []
 
 [dependencies]
 sphinx-glyph = { path = '../glyph', default-features = false }
@@ -32,9 +33,9 @@ fsdb = { git = "https://github.com/Evanfeenstra/fsdb.git", rev = "7d0db454133bf3
 # fsdb = { path = "../../fsdb", optional = true }
 thiserror = "1.0.44"
 # vls
-vls-protocol-signer = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "9708f5281afe27a2ac5460679ba62a28567b79dc", default-features = false, features = ["secp-lowmemory", "tracker_size_workaround"] }
-vls-protocol = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "9708f5281afe27a2ac5460679ba62a28567b79dc", default-features = false }
-vls-persist = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "9708f5281afe27a2ac5460679ba62a28567b79dc", default-features = false, features = ["kvv"], optional = true }
+vls-protocol-signer = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "300495658a1903a45a081771fdf2fe6883b057a7", default-features = false, features = ["secp-lowmemory", "tracker_size_workaround"] }
+vls-protocol = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "300495658a1903a45a081771fdf2fe6883b057a7", default-features = false }
+vls-persist = { git = "https://gitlab.com/lightning-signer/validating-lightning-signer.git", rev = "300495658a1903a45a081771fdf2fe6883b057a7", default-features = false, features = ["kvv"], optional = true }
 # local
 # vls-protocol-signer = { path = "../../vls/vls-protocol-signer", default-features = false, features = ["secp-lowmemory", "tracker_size_workaround"] }
 # vls-protocol = { path = "../../vls/vls-protocol", default-features = false }

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod approver;
 pub mod derive;
+#[cfg(not(feature = "lowmemory"))]
 pub mod mobile;
 pub mod parser;
 pub mod root;


### PR DESCRIPTION
pull vls chunked-filter work, see `chunked-buffer`, `serde_bolt`, `txoo` crates for details.

The tldr is that we now use the `chunked_buffer::GenericChunkedBuffer` structure, imported here as `serde_bolt::NonContiguousOctets` for both the MQTT bytes, and the `ProofType::Filter` structure in txoo.

Key features of `NonContiguousBytes`:
- Max contiguous memory block size: 1024 bytes.
- Bytes are progressively de-allocated from memory as they are read.
- As bytes are written to the structure, no reallocation of the bytes themselves ever occurs. We instead keep allocating independent, 1024-byte blocks of memory as necessary.

The use of this structure achieves the following:
- Completely eliminates the source of **all** of our out-of-memory crashes up until this point.
- Reduces the max contiguous memory block size from 45KB to 1KiB when creating both of these structures, which increases the efficiency of our memory usage. 
- Decreases peak memory usage by progressively deallocating the mqtt bytes and allocating the `ProofType::Filter` bytes as the parse occurs. We previously needed space for 2 45KB contiguous memory blocks, (1 for the MQTT bytes, and one for the `Filter` bytes). This resulted in very premature out-of-memory crashes, ie memory crash when still 90KB of memory available. This is because the MQTT bytes were deallocated only once the full `Filter` structure had been created.

```
total: 91K, max block: 37K
msgs::read
memory allocation of 39235 bytes failed
```